### PR TITLE
Propogate error back to middleware when serving files

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -39,7 +39,7 @@ module.exports = function getMiddleware(watcher, options) {
         stat = fs.statSync(filename)
       } catch (e) {
         // not found
-        next()
+        next(e)
         return
       }
 


### PR DESCRIPTION
This PR bubbles the error back to the middleware that is supposed to serve the files. For example, serve-files [middleware])https://github.com/ember-cli/ember-cli/blob/master/lib/tasks/server/middleware/serve-files/index.js#L46) expects an optional `err` attribute and logs the error. If an asset is being requested to be served and is not present, the error will never be thrown. User will only know about the asset not being served if they opened the network tab in a developer options.

Testing:
1. Tested ti with a dummy app that requested for a non existent asset and got the error stacktrace thrown in the serve logs.

PS: 
1. This repo needs some love to improve code readability. Will send another PR to beatify the code.
2. No tests in this repo? 😱 

cc: @stefanpenner @rwjblue @chadhietala @nathanhammond 