### PR TITLE
Use done() instead of returning the promise for two tests.

### DIFF
--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -42,6 +42,7 @@ describe('broccoli-middleware', function() {
     });
 
     it('responds with error if file not found', function(done) {
+
       watcher['builder']['outputPath'] = fixture('basic-file');
       var middleware = broccoliMiddleware(watcher, {
         autoIndex: false
@@ -49,14 +50,15 @@ describe('broccoli-middleware', function() {
 
       var wrapperMiddleware = function(req, resp /*next*/) {
         middleware(req, resp, function(err) {
-          expect(resp.finished).to.be.false;
+          var isRequestFinished = resp.finished;
+          expect(isRequestFinished).to.be.false;
           expect(err.message).to.have.string('ENOENT');
           done();
         })
       };
-      server = new TestHTTPServer(wrapperMiddleware);
 
-      return server.start()
+      server = new TestHTTPServer(wrapperMiddleware);
+      server.start()
         .then(function(info) {
           return server.request('/non-existent-file', {
             info: info
@@ -79,7 +81,7 @@ describe('broccoli-middleware', function() {
       };
       server = new TestHTTPServer(wrapperMiddleware);
 
-      return server.start()
+      server.start()
         .then(function(info) {
           return server.request('', {
             info: info


### PR DESCRIPTION
In order to run assertions in middleware correctly, we will need to use the `done` mechanism instead of returning a promise. This was the quickest solution I could come up with. 

Please let me know if there is a better way. This assertion was introduced as a [breaking change in Mocha 3.0.0](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#300--2016-07-31).

I need to make sure to execute the next middleware to check if request finished or not and there is no straightforward way. I can check on the error object only using promise API but that doesn't suffice the purpose of the test.

cc: @Turbo87 