### PR TITLE
Streaming Media support for local file serving

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,136 +1,148 @@
-'use strict';
+var path = require('path')
+var fs = require('fs')
 
-var path = require('path');
-var fs = require('fs');
+var handlebars = require('handlebars')
+var url = require('url')
+var mime = require('mime')
 
-var handlebars = require('handlebars');
-var url = require('url');
-var mime = require('mime');
+var errorTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '../templates/error.html')).toString())
+var dirTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '../templates/dir.html')).toString())
 
-var errorTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, 'templates/error.html')).toString());
-var dirTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, 'templates/dir.html')).toString());
-
-// You must call watcher.watch() before you call `getMiddleware`
-//
-// This middleware is for development use only. It hasn't been reviewed
-// carefully enough to run on a production server.
-//
 // Supported options:
 //   autoIndex (default: true) - set to false to disable directory listings
 //   liveReloadPath - LiveReload script URL for error pages
 module.exports = function getMiddleware(watcher, options) {
-  var outputPath = watcher.builder.outputPath;
-  options = options || {};
-
-  if (!options.hasOwnProperty('autoIndex')) {
-    // set autoIndex to be true if not provided
-    options.autoIndex = true;
-  }
+  if (options == null) options = {}
+  if (options.autoIndex == null) options.autoIndex = true
 
   return function broccoliMiddleware(request, response, next) {
-    watcher.then(function() {
-      var urlObj = url.parse(request.url);
-      var filename = path.join(outputPath, decodeURIComponent(urlObj.pathname));
-      var stat, lastModified, type, charset, buffer;
+    watcher.then(function(hash) {
+      var directory = path.normalize(hash.directory)
+      var urlObj = url.parse(request.url)
+      var filename = path.join(directory, decodeURIComponent(urlObj.pathname))
+      var stat, lastModified, type, charset, buffer
+
+      // this middleware is for development use only
 
       // contains null byte or escapes directory
-      if (filename.indexOf('\0') !== -1 || filename.indexOf(outputPath) !== 0) {
-        response.writeHead(400);
-        response.end();
-        return;
+      if (filename.indexOf('\0') !== -1 || filename.indexOf(directory) !== 0) {
+        response.writeHead(400)
+        response.end()
+        return
       }
 
       try {
-        stat = fs.statSync(filename);
+        stat = fs.statSync(filename)
       } catch (e) {
-        // asset not found
-        next(e);
-        return;
+        // not found
+        next()
+        return
       }
 
       if (stat.isDirectory()) {
-        var hasIndex = fs.existsSync(path.join(filename, 'index.html'));
+        var hasIndex = fs.existsSync(path.join(filename, 'index.html'))
 
         if (!hasIndex && !options.autoIndex) {
-          // if index.html not present and autoIndex is not turned on, move to the next
-          // middleware (if present) to find the asset.
-          next();
-          return;
+          next()
+          return
         }
 
         // If no trailing slash, redirect. We use path.sep because filename
         // has backslashes on Windows.
         if (filename[filename.length - 1] !== path.sep) {
-          urlObj.pathname += '/';
-          response.setHeader('Location', url.format(urlObj));
-          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
-          response.writeHead(301);
-          response.end();
-          return;
+          urlObj.pathname += '/'
+          response.setHeader('Location', url.format(urlObj))
+          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
+          response.writeHead(301)
+          response.end()
+          return
         }
 
         if (!hasIndex) { // implied: options.autoIndex is true
           var context = {
             url: request.url,
-            files: fs.readdirSync(filename).sort().map(function (child) {
+            files: fs.readdirSync(filename).sort().map(function (child){
               var stat = fs.statSync(path.join(filename,child)),
-                  isDir = stat.isDirectory();
+                isDir = stat.isDirectory()
               return {
                 href: child + (isDir ? '/' : ''),
                 type: isDir ? 'dir' : path.extname(child).replace('.', '').toLowerCase()
-              };
+              }
             }),
             liveReloadPath: options.liveReloadPath
-          };
-          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
-          response.writeHead(200);
-          response.end(dirTemplate(context));
-          return;
+          }
+          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
+          response.writeHead(200)
+          response.end(dirTemplate(context))
+          return
         }
 
         // otherwise serve index.html
-        filename += 'index.html';
-        stat = fs.statSync(filename);
+        filename += 'index.html'
+        stat = fs.statSync(filename)
       }
 
-      lastModified = stat.mtime.toUTCString();
-      response.setHeader('Last-Modified', lastModified);
-
+      lastModified = stat.mtime.toUTCString()
+      response.setHeader('Last-Modified', lastModified)
+      // nginx style treat last-modified as a tag since browsers echo it back
       if (request.headers['if-modified-since'] === lastModified) {
-        // nginx style treat last-modified as a tag since browsers echo it back
-        response.writeHead(304);
-        response.end();
-        return;
+        response.writeHead(304)
+        response.end()
+        return
       }
 
-      type = mime.lookup(filename);
-      charset = mime.charsets.lookup(type);
+      type = mime.lookup(filename)
+      charset = mime.charsets.lookup(type)
       if (charset) {
-        type += '; charset=' + charset;
+        type += '; charset=' + charset
       }
-      response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
-      response.setHeader('Content-Length', stat.size);
-      response.setHeader('Content-Type', type);
 
-      // read file sync so we don't hold open the file creating a race with
-      // the builder (Windows does not allow us to delete while the file is open).
-      buffer = fs.readFileSync(filename);
-      response.writeHead(200);
-      response.end(buffer);
+      var range = request.headers.range || "";
+      var total = stat.size;
+
+      if (range) {
+        var parts = range.replace(/bytes=/, "").split("-");
+        var partialStart = parts[0];
+        var partialEnd = parts[1];
+
+        var start = parseInt(partialStart, 10);
+        var end = partialEnd ? parseInt(partialEnd, 10) : total - 1;
+        var chunkSize = (end - start) + 1;
+        console.log(parts, start, end, chunkSize);
+ 
+        response.setHeader('Accept-Ranges', 'bytes');
+        response.setHeader('Content-Length', stat.size);
+        response.setHeader('Content-Type', type);
+        response.setHeader("Content-Range", "bytes " + start + "-" + end + "/" + total);
+
+        response.writeHead(206);
+
+        var readStream = fs.createReadStream(filename, {start: start, end: end});
+        readStream.pipe(response);
+      } else {
+        response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
+        response.setHeader('Content-Length', stat.size)
+        response.setHeader('Content-Type', type)
+
+        // read file sync so we don't hold open the file creating a race with
+        // the builder (Windows does not allow us to delete while the file is open).
+        buffer = fs.readFileSync(filename)
+        response.writeHead(200)
+        response.end(buffer)
+      }
     }, function(buildError) {
-      // All errors thrown from builder.build() are guaranteed to be
-      // Builder.BuildError instances.
       var context = {
+        message: buildError.message || buildError,
+        file: buildError.file,
+        treeDir: buildError.treeDir,
+        line: buildError.line,
+        column: buildError.column,
         stack: buildError.stack,
-        liveReloadPath: options.liveReloadPath,
-        payload: buildError.broccoliPayload
-      };
-      response.setHeader('Content-Type', 'text/html');
-      response.writeHead(500);
-      response.end(errorTemplate(context));
-    }).
-    catch(function(err) {
-      console.log(err.stack);
-    });
-  };
-};
+        liveReloadPath: options.liveReloadPath
+      }
+      response.setHeader('Content-Type', 'text/html')
+      response.writeHead(500)
+      response.end(errorTemplate(context))
+    }).catch(function(err) { console.log(err) })
+  }
+}

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,106 +1,122 @@
-var path = require('path')
-var fs = require('fs')
+'use strict';
 
-var handlebars = require('handlebars')
-var url = require('url')
-var mime = require('mime')
+var path = require('path');
+var fs = require('fs');
 
-var errorTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '../templates/error.html')).toString())
-var dirTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, '../templates/dir.html')).toString())
+var handlebars = require('handlebars');
+var url = require('url');
+var mime = require('mime');
 
+var errorTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, 'templates/error.html')).toString());
+var dirTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, 'templates/dir.html')).toString());
+
+// You must call watcher.watch() before you call `getMiddleware`
+//
+// This middleware is for development use only. It hasn't been reviewed
+// carefully enough to run on a production server.
+//
 // Supported options:
 //   autoIndex (default: true) - set to false to disable directory listings
 //   liveReloadPath - LiveReload script URL for error pages
 module.exports = function getMiddleware(watcher, options) {
-  if (options == null) options = {}
-  if (options.autoIndex == null) options.autoIndex = true
+  var outputPath = watcher.builder.outputPath;
+  options = options || {};
+
+  if (!options.hasOwnProperty('autoIndex')) {
+    // set autoIndex to be true if not provided
+    options.autoIndex = true;
+  }
 
   return function broccoliMiddleware(request, response, next) {
-    watcher.then(function(hash) {
-      var directory = path.normalize(hash.directory)
-      var urlObj = url.parse(request.url)
-      var filename = path.join(directory, decodeURIComponent(urlObj.pathname))
-      var stat, lastModified, type, charset, buffer
-
-      // this middleware is for development use only
+    watcher.then(function() {
+      var urlObj = url.parse(request.url);
+      var filename = path.join(outputPath, decodeURIComponent(urlObj.pathname));
+      var stat, lastModified, type, charset, buffer;
 
       // contains null byte or escapes directory
-      if (filename.indexOf('\0') !== -1 || filename.indexOf(directory) !== 0) {
-        response.writeHead(400)
-        response.end()
-        return
+      if (filename.indexOf('\0') !== -1 || filename.indexOf(outputPath) !== 0) {
+        response.writeHead(400);
+        response.end();
+        return;
       }
 
       try {
-        stat = fs.statSync(filename)
+        stat = fs.statSync(filename);
       } catch (e) {
-        // not found
-        next()
-        return
+        // asset not found
+        next(e);
+        return;
       }
 
       if (stat.isDirectory()) {
-        var hasIndex = fs.existsSync(path.join(filename, 'index.html'))
+        var hasIndex = fs.existsSync(path.join(filename, 'index.html'));
 
         if (!hasIndex && !options.autoIndex) {
-          next()
-          return
+          // if index.html not present and autoIndex is not turned on, move to the next
+          // middleware (if present) to find the asset.
+          next();
+          return;
         }
 
         // If no trailing slash, redirect. We use path.sep because filename
         // has backslashes on Windows.
         if (filename[filename.length - 1] !== path.sep) {
-          urlObj.pathname += '/'
-          response.setHeader('Location', url.format(urlObj))
-          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
-          response.writeHead(301)
-          response.end()
-          return
+          urlObj.pathname += '/';
+          response.setHeader('Location', url.format(urlObj));
+          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
+          response.writeHead(301);
+          response.end();
+          return;
         }
 
         if (!hasIndex) { // implied: options.autoIndex is true
           var context = {
             url: request.url,
-            files: fs.readdirSync(filename).sort().map(function (child){
+            files: fs.readdirSync(filename).sort().map(function (child) {
               var stat = fs.statSync(path.join(filename,child)),
-                isDir = stat.isDirectory()
+                  isDir = stat.isDirectory();
               return {
                 href: child + (isDir ? '/' : ''),
                 type: isDir ? 'dir' : path.extname(child).replace('.', '').toLowerCase()
-              }
+              };
             }),
             liveReloadPath: options.liveReloadPath
-          }
-          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
-          response.writeHead(200)
-          response.end(dirTemplate(context))
-          return
+          };
+          response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
+          response.writeHead(200);
+          response.end(dirTemplate(context));
+          return;
         }
 
         // otherwise serve index.html
-        filename += 'index.html'
-        stat = fs.statSync(filename)
+        filename += 'index.html';
+        stat = fs.statSync(filename);
       }
 
-      lastModified = stat.mtime.toUTCString()
-      response.setHeader('Last-Modified', lastModified)
-      // nginx style treat last-modified as a tag since browsers echo it back
+      lastModified = stat.mtime.toUTCString();
+      response.setHeader('Last-Modified', lastModified);
+
       if (request.headers['if-modified-since'] === lastModified) {
-        response.writeHead(304)
-        response.end()
-        return
+        // nginx style treat last-modified as a tag since browsers echo it back
+        response.writeHead(304);
+        response.end();
+        return;
       }
 
-      type = mime.lookup(filename)
-      charset = mime.charsets.lookup(type)
+      type = mime.lookup(filename);
+      charset = mime.charsets.lookup(type);
       if (charset) {
-        type += '; charset=' + charset
+        type += '; charset=' + charset;
       }
 
+      // check to see if this is streamable media
       var range = request.headers.range || "";
       var total = stat.size;
 
       if (range) {
+        // parse the byte window we're trying to serve from, with
+        // 0 as the byte marker to start from
+        // 1 as the byte marker of the end (or window, but usually the end of the media)
         var parts = range.replace(/bytes=/, "").split("-");
         var partialStart = parts[0];
         var partialEnd = parts[1];
@@ -108,7 +124,6 @@ module.exports = function getMiddleware(watcher, options) {
         var start = parseInt(partialStart, 10);
         var end = partialEnd ? parseInt(partialEnd, 10) : total - 1;
         var chunkSize = (end - start) + 1;
-        console.log(parts, start, end, chunkSize);
  
         response.setHeader('Accept-Ranges', 'bytes');
         response.setHeader('Content-Length', stat.size);
@@ -120,29 +135,30 @@ module.exports = function getMiddleware(watcher, options) {
         var readStream = fs.createReadStream(filename, {start: start, end: end});
         readStream.pipe(response);
       } else {
-        response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate')
-        response.setHeader('Content-Length', stat.size)
-        response.setHeader('Content-Type', type)
+        response.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
+        response.setHeader('Content-Length', stat.size);
+        response.setHeader('Content-Type', type);
 
         // read file sync so we don't hold open the file creating a race with
         // the builder (Windows does not allow us to delete while the file is open).
-        buffer = fs.readFileSync(filename)
-        response.writeHead(200)
-        response.end(buffer)
+        buffer = fs.readFileSync(filename);
+        response.writeHead(200);
+        response.end(buffer);
       }
     }, function(buildError) {
+      // All errors thrown from builder.build() are guaranteed to be
+      // Builder.BuildError instances.
       var context = {
-        message: buildError.message || buildError,
-        file: buildError.file,
-        treeDir: buildError.treeDir,
-        line: buildError.line,
-        column: buildError.column,
         stack: buildError.stack,
-        liveReloadPath: options.liveReloadPath
-      }
-      response.setHeader('Content-Type', 'text/html')
-      response.writeHead(500)
-      response.end(errorTemplate(context))
-    }).catch(function(err) { console.log(err) })
-  }
-}
+        liveReloadPath: options.liveReloadPath,
+        payload: buildError.broccoliPayload
+      };
+      response.setHeader('Content-Type', 'text/html');
+      response.writeHead(500);
+      response.end(errorTemplate(context));
+    }).
+    catch(function(err) {
+      console.log(err.stack);
+    });
+  };
+};

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -110,25 +110,24 @@ module.exports = function getMiddleware(watcher, options) {
       }
 
       // check to see if this is streamable media
-      var range = request.headers.range || "";
+      var range = request.headers.range || '';
       var total = stat.size;
 
       if (range) {
         // parse the byte window we're trying to serve from, with
         // 0 as the byte marker to start from
         // 1 as the byte marker of the end (or window, but usually the end of the media)
-        var parts = range.replace(/bytes=/, "").split("-");
+        var parts = range.replace(/bytes=/, '').split('-');
         var partialStart = parts[0];
         var partialEnd = parts[1];
 
         var start = parseInt(partialStart, 10);
         var end = partialEnd ? parseInt(partialEnd, 10) : total - 1;
-        var chunkSize = (end - start) + 1;
- 
+
         response.setHeader('Accept-Ranges', 'bytes');
         response.setHeader('Content-Length', stat.size);
         response.setHeader('Content-Type', type);
-        response.setHeader("Content-Range", "bytes " + start + "-" + end + "/" + total);
+        response.setHeader('Content-Range', 'bytes ' + start + '-' + end + '/' + total);
 
         response.writeHead(206);
 

--- a/test/helpers/test-http-server.js
+++ b/test/helpers/test-http-server.js
@@ -59,7 +59,7 @@ TestHTTPServer.prototype.start = function() {
 TestHTTPServer.prototype.request = function(urlPath, options) {
   var info = options.info;
   var url = 'http://[' + info.host + ']:' + info.port;
-  return request(url + urlPath);
+  return request(url + urlPath, options);
 }
 
 /**

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -134,14 +134,7 @@ describe('broccoli-middleware', function() {
         autoIndex: false
       });
 
-      var wrapperMiddleware = function(req, resp /*next*/) {
-        middleware(req, resp, function() {
-          console.log(resp.headers);
-
-        })
-      };
-
-      server = new TestHTTPServer(wrapperMiddleware);
+      server = new TestHTTPServer(middleware);
       server.start()
         .then(function(info) {
           return server.request('/index.html', {
@@ -162,14 +155,7 @@ describe('broccoli-middleware', function() {
         autoIndex: false
       });
 
-      var wrapperMiddleware = function(req, resp /*next*/) {
-        middleware(req, resp, function() {
-          console.log(resp.headers);
-
-        })
-      };
-
-      server = new TestHTTPServer(wrapperMiddleware);
+      server = new TestHTTPServer(middleware);
       server.start()
         .then(function(info) {
           return server.request('/index.html', {

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -127,28 +127,28 @@ describe('broccoli-middleware', function() {
         });
     });
 
-    it('responds to streaming media requests when Range headers are requested', function (done) {
+    it('responds to streaming media requests when Range headers are requested', function () {
 
       watcher['builder']['outputPath'] = fixture('basic-file');
       var middleware = broccoliMiddleware(watcher, {
         autoIndex: false
       });
 
+
       server = new TestHTTPServer(middleware);
-      server.start()
+      return server.start()
         .then(function(info) {
           return server.request('/index.html', {
-            headers: { 'Range': 'bytes=0-6'},
+            headers: {'Range': 'bytes=0-6'},
             info: info
           });
         })
         .then(function (content) {
           expect(content).to.match(/<html>/);
-          done();
-        })
+        });
     });
 
-    it('appropriately delivers byte slices corresponding to header Range values', function (done) {
+    it('appropriately delivers byte slices corresponding to header Range values', function () {
 
       watcher['builder']['outputPath'] = fixture('basic-file');
       var middleware = broccoliMiddleware(watcher, {
@@ -156,17 +156,16 @@ describe('broccoli-middleware', function() {
       });
 
       server = new TestHTTPServer(middleware);
-      server.start()
+      return server.start()
         .then(function(info) {
           return server.request('/index.html', {
-            headers: { 'Range': 'bytes=100-108'},
+            headers: {'Range': 'bytes=100-107'},
             info: info
           });
         })
         .then(function (content) {
           expect(content).to.match(/broccoli/);
-          done();
-        })
+        });
     });
   });
 

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -126,6 +126,62 @@ describe('broccoli-middleware', function() {
           expect(content).to.match(/This is broccoli middleware page/);
         });
     });
+
+    it('responds to streaming media requests when Range headers are requested', function (done) {
+
+      watcher['builder']['outputPath'] = fixture('basic-file');
+      var middleware = broccoliMiddleware(watcher, {
+        autoIndex: false
+      });
+
+      var wrapperMiddleware = function(req, resp /*next*/) {
+        middleware(req, resp, function() {
+          console.log(resp.headers);
+
+        })
+      };
+
+      server = new TestHTTPServer(wrapperMiddleware);
+      server.start()
+        .then(function(info) {
+          return server.request('/index.html', {
+            headers: { 'Range': 'bytes=0-6'},
+            info: info
+          });
+        })
+        .then(function (content) {
+          expect(content).to.match(/<html>/);
+          done();
+        })
+    });
+
+    it('appropriately delivers byte slices corresponding to header Range values', function (done) {
+
+      watcher['builder']['outputPath'] = fixture('basic-file');
+      var middleware = broccoliMiddleware(watcher, {
+        autoIndex: false
+      });
+
+      var wrapperMiddleware = function(req, resp /*next*/) {
+        middleware(req, resp, function() {
+          console.log(resp.headers);
+
+        })
+      };
+
+      server = new TestHTTPServer(wrapperMiddleware);
+      server.start()
+        .then(function(info) {
+          return server.request('/index.html', {
+            headers: { 'Range': 'bytes=100-108'},
+            info: info
+          });
+        })
+        .then(function (content) {
+          expect(content).to.match(/broccoli/);
+          done();
+        })
+    });
   });
 
   describe('watcher is rejected', function() {


### PR DESCRIPTION
Middleware didn't provide a way to serve requests for streaming / buffering of media.   this small little PR looks for the appropriate request headers for that style of request, and will `stream.pipe()` that data to the client when applicable, otherwise falling back to middlewares original static file serving mechanism. 


relevant changes are from L116-L137