### PR TITLE
Drop Node 0.10 support from `broccoli-middleware`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
-  - "iojs-v1.0.0"
+  - "4"
+  - "6"
   - "node"
 sudo: false


### PR DESCRIPTION
I don't think `ember-cli` supports Node 0.10 anymore so it would be nice if we drop support from this repo too.

cc: @stefanpenner @rwjblue 