### PR TITLE
Read assets from the `tmp` directory instead of `dist`.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -19,7 +19,6 @@ var dirTemplate = handlebars.compile(fs.readFileSync(path.resolve(__dirname, 'te
 //   autoIndex (default: true) - set to false to disable directory listings
 //   liveReloadPath - LiveReload script URL for error pages
 module.exports = function getMiddleware(watcher, options) {
-  var outputPath = watcher.builder.outputPath;
   options = options || {};
 
   if (!options.hasOwnProperty('autoIndex')) {
@@ -28,7 +27,8 @@ module.exports = function getMiddleware(watcher, options) {
   }
 
   return function broccoliMiddleware(request, response, next) {
-    watcher.then(function() {
+    watcher.then(function(hash) {
+      var outputPath = path.normalize(hash.directory);
       var urlObj = url.parse(request.url);
       var filename = path.join(outputPath, decodeURIComponent(urlObj.pathname));
       var stat, lastModified, type, charset, buffer;

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -8,14 +8,7 @@ var TestHTTPServer = require('./helpers/test-http-server');
 
 describe('broccoli-middleware', function() {
   describe('watcher resolves correctly', function() {
-    var watcher;
     var server;
-
-    beforeEach(function() {
-      watcher = RSVP.Promise.resolve();
-
-      watcher['builder'] = {};
-    });
 
     afterEach(function() {
       server.stop();
@@ -23,7 +16,9 @@ describe('broccoli-middleware', function() {
     })
 
     it('responds with the given file if file is on disk', function() {
-      watcher['builder']['outputPath'] = fixture('basic-file');
+      var watcher = RSVP.Promise.resolve({
+        'directory': fixture('basic-file')
+      });
       var middleware = broccoliMiddleware(watcher, {
         autoIndex: false
       });
@@ -42,8 +37,10 @@ describe('broccoli-middleware', function() {
     });
 
     it('responds with error if file not found', function(done) {
+      var watcher = RSVP.Promise.resolve({
+        'directory': fixture('basic-file')
+      });
 
-      watcher['builder']['outputPath'] = fixture('basic-file');
       var middleware = broccoliMiddleware(watcher, {
         autoIndex: false
       });
@@ -67,7 +64,10 @@ describe('broccoli-middleware', function() {
     });
 
     it('bypasses broccoli-middleware if request is a directory and autoIndex is set to false', function(done) {
-      watcher['builder']['outputPath'] = fixture('no-index');
+      var watcher = RSVP.Promise.resolve({
+        'directory': fixture('no-index')
+      });
+
       var middleware = broccoliMiddleware(watcher, {
         autoIndex: false
       });
@@ -90,7 +90,10 @@ describe('broccoli-middleware', function() {
     });
 
     it('responds with directory structure template if request is a directory and autoIndex is set to true', function() {
-      watcher['builder']['outputPath'] = fixture('no-index');
+      var watcher = RSVP.Promise.resolve({
+        'directory': fixture('no-index')
+      });
+
       var middleware = broccoliMiddleware(watcher, {
         autoIndex: true
       });
@@ -109,7 +112,10 @@ describe('broccoli-middleware', function() {
     });
 
     it('responds with index.html if request is a directory and autoIndex is set to false', function() {
-      watcher['builder']['outputPath'] = fixture('basic-file');
+      var watcher = RSVP.Promise.resolve({
+        'directory': fixture('basic-file')
+      });
+
       var middleware = broccoliMiddleware(watcher, {
         autoIndex: true
       });
@@ -147,7 +153,6 @@ describe('broccoli-middleware', function() {
     })
 
     it('returns HTTP 500 when there is build error', function() {
-      watcher['builder']['outputPath'] = fixture('basic-file');
       var middleware = broccoliMiddleware(watcher, {
         autoIndex: false
       });


### PR DESCRIPTION
watcher outputPath points to dist directory after `outputReady` is emmitted. `ember serve` by default should be serving assets from the `tmp` directory. With the latest version of `broccoli-middleware` we will end up serving from `dist` directory instead of `tmp`. Luckily we have pinned the version of `broccoli-middleware` in `ember-cli`. But this PR will fix a _future_ regression.

There is no way to add an integration test with `ember-cli` currently because we mock `hash.directory` in tests. I will think about how we can write integration tests with `ember-cli` to prevent such future regressions (though I don't think it should block this PR). 

Tested it manually with `npm link` to ember cli and a dummy app.

cc: @stefanpenner @rwjblue @Turbo87 