### PR TITLE
Use `key` as a variable, not as string "key"

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -15,7 +15,7 @@ module.exports = function errorHandler(response, options) {
   const versions = broccoliPayload.versions || {};
 
   const versionString = Object.keys(versions).sort().map((key) => {
-    return versions[key] ? `{key}@${versions[key]}` : '';
+    return versions[key] ? `${key}@${versions[key]}` : '';
   }).join(', ');
 
   const context = {


### PR DESCRIPTION
Versions of `broccoli-builder` & `node` were not reported correctly and appeared as `{key}@0.18.5`