### PR TITLE
Update travis to run on Node 8 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "4"
   - "6"
   - "7"
+  - "8"
+  - "stable"
 sudo: false
 
 cache:


### PR DESCRIPTION
`ember-cli` supports Node 8, therefore make sure we run tests against Node 8 as well.

cc: @stefanpenner 