### PR TITLE
Enable scrolling when the callstack's height is > 600px

### DIFF
--- a/lib/templates/error.html
+++ b/lib/templates/error.html
@@ -41,7 +41,7 @@
       .callstack {
         transition: height 0.5s;
         height: 0px;
-        overflow: hidden;
+        overflow: auto;
       }
       .callstack h4 {
         margin-top: 0;


### PR DESCRIPTION
Right now, the callstack is cut off when > 600px and you need to inspect the DOM to see the rest of it.