### PR TITLE
Add utf-8 encoding to properly display emoji in error page

### DIFF
--- a/lib/templates/error.html
+++ b/lib/templates/error.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>{{errorType}}</title>
+    <meta charset="utf-8">
     {{#if liveReloadPath}}
       <script src="{{liveReloadPath}}"></script>
     {{/if}}


### PR DESCRIPTION
Before:

<img width="1075" alt="screen shot 2018-07-03 at 9 49 53 pm" src="https://user-images.githubusercontent.com/7725225/42232231-66318500-7f0b-11e8-8387-213be6b6bbd9.png">

After:

<img width="1080" alt="screen shot 2018-07-03 at 9 50 23 pm" src="https://user-images.githubusercontent.com/7725225/42232230-65fbb89e-7f0b-11e8-9133-631da5651610.png">

