### PR TITLE
Enable syntax highlighting in error stacks

### DIFF
--- a/lib/templates/error.html
+++ b/lib/templates/error.html
@@ -14,9 +14,14 @@
       }
       pre, code {
         font-size: 15px;
-        color: #865931;
+        color: #EFEBEA;
         margin: 0;
         font-family: "SFMono-Light", monospace;
+        background: #212121;
+        overflow: scroll;
+      }
+      pre {
+        padding: 15px;
       }
       ul {
         list-style: none;
@@ -59,7 +64,13 @@
       }
       .callstack pre, .callstack code {
         font-size: 12px;
-        color: #865931;
+        color: #817F7F;
+      }
+      .message {
+        background: #212121;
+        color: #EFEBEA;
+        font-weight: normal;
+        line-height: 1.8em;
       }
       .collapsible {
         padding-top: 25px;
@@ -1091,31 +1102,34 @@ ErkJggg==" />
           <h2 class="error-message">{{location.file}}{{#if location.line}}:{{location.line}}{{/if}}</h2>
         {{/if}}
 
-        {{#if codeFrame}}
-          <pre><code class="javascript">{{codeFrame}}</code></pre>
-        {{/if}}
+          {{#if codeFrame}}
+            <pre><code class="javascript">{{#if hasAnsi}}{{{codeFrame}}}{{else}}{{codeFrame}}{{/if}}</code></pre>
+          {{/if}}
+        </div>
 
         <div class="collapsible">
           <input id="toggle" type="checkbox">
           <label for="toggle">Expand stack frames</label>
           <div class="callstack">
             <h3>Broccoli Plugin: {{nodeName}}</h3>
-            <h4>{{errorMessage}}</h4>
+            <h4 class="message">
+              <pre><code>{{#if hasAnsi}}{{{errorMessage}}}{{else}}{{errorMessage}}{{/if}}</code></pre>
+            </h4>
             {{#if stack}}
               <pre>
-                <code class="markdown">{{stack}}</code>
+                <code class="markdown">{{#if hasAnsi}}{{{stack}}}{{else}}{{stack}}{{/if}}</code>
               </pre>
             {{/if}}
 
             {{#if instantiationStack}}
               <pre>
-                <code class="markdown">{{instantiationStack}}</code>
+                <code class="markdown">{{#if hasAnsi}}{{{instantiationStack}}}{{else}}{{instantiationStack}}{{/if}}</code>
               </pre>
             {{/if}}
 
             {{#if broccoliBuilderErrorStack}}
               <pre>
-                <code class="markdown">{{broccoliBuilderErrorStack}}</code>
+                <code class="markdown">{{#if hasAnsi}}{{{broccoliBuilderErrorStack}}}{{else}}{{broccoliBuilderErrorStack}}{{/if}}</code>
               </pre>
             {{/if}}
           </div>

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -9,6 +9,14 @@ const errorHandlerUtils = require('./error-handler-utils');
 
 const toVersionString = errorHandlerUtils.toVersionString;
 
+const hasAnsi = require('has-ansi');
+const ansiHTML = require('ansi-html');
+// Resets foreground and background colors to black
+// and white respectively
+ansiHTML.setColors({
+  reset: ['#000', '#fff'],
+});
+
 module.exports = function errorHandler(response, options) {
   // All errors thrown from builder.build() are guaranteed to be
   // Builder.BuildError instances.
@@ -20,16 +28,17 @@ module.exports = function errorHandler(response, options) {
   const versionString = toVersionString(versions);
 
   const context = {
-    stack: broccoliPayload.error.stack,
-    broccoliBuilderErrorStack: buildError.stack,
-    instantiationStack: broccoliPayload.instantiationStack,
-    errorMessage: buildError.message,
+    stack: ansiHTML(broccoliPayload.error.stack),
+    broccoliBuilderErrorStack: ansiHTML(buildError.stack),
+    instantiationStack: ansiHTML(broccoliPayload.instantiationStack),
+    errorMessage: ansiHTML(buildError.message),
     liveReloadPath: options.liveReloadPath,
-    codeFrame: broccoliPayload.error.codeFrame,
+    codeFrame: ansiHTML(broccoliPayload.error.codeFrame),
     nodeName: broccoliNode.nodeName,
     nodeAnnotation: broccoliNode.nodeAnnotation,
     errorType: broccoliPayload.error.errorType,
     location: broccoliPayload.error.location,
+    hasAnsi: hasAnsi(broccoliPayload.error.stack),
     versionString
   };
   response.setHeader('Content-Type', 'text/html');

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "homepage": "https://github.com/ember-cli/broccoli-middleware",
   "dependencies": {
-    "handlebars": "^4.0.13",
+    "ansi-html": "^0.0.7",
+    "handlebars": "^4.0.4",
+    "has-ansi": "^3.0.0",
     "mime-types": "^2.1.18"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,9 +50,19 @@ ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
+ansi-html@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
+  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -790,6 +800,13 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-ansi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-3.0.0.tgz#36077ef1d15f333484aa7fa77a28606f1c655b37"
+  integrity sha1-Ngd+8dFfMzSEqn+neihgbxxlWzc=
+  dependencies:
+    ansi-regex "^3.0.0"
 
 has-flag@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Mostly ported from https://github.com/broccolijs/broccoli/pull/415

Babel transpilation errors:

<img width="580" alt="Screen Shot 2019-07-02 at 00 19 34" src="https://user-images.githubusercontent.com/7725225/60459594-39611280-9c5f-11e9-93cf-8a1c4e262a4c.png">

HBS compilation errors:

<img width="562" alt="Screen Shot 2019-07-02 at 00 18 21" src="https://user-images.githubusercontent.com/7725225/60459605-40882080-9c5f-11e9-9f81-afa90f014620.png">
